### PR TITLE
Use a cloud browser in the README quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,18 +8,20 @@ The agent gets a persistent JS session, an accessibility tree, screenshots, and 
 
 ## Start
 
-Runs in **Node 22.19+** or **Bun 1.3.14+**. Bun also needs Node installed for the execution worker. Use local Chrome or a [cloud browser](https://github.com/browser-use/browser-use-js/blob/main/docs/sessions.md). Install with npm, pnpm or Bun:
+Runs in **Node 22.19+** or **Bun 1.3.14+**. Bun also needs Node installed for the execution worker. The example uses [Browser Use Cloud](https://github.com/browser-use/browser-use-js/blob/main/docs/sessions.md), so no local Chrome installation is needed. Install with npm, pnpm or Bun:
 
 ```sh
 npm install @browser_use/js
 export OPENROUTER_API_KEY=...
+export BROWSER_USE_API_KEY=...
 ```
 
 ```ts
-import { BrowserUse } from '@browser_use/js';
+import { Browser, BrowserUse } from '@browser_use/js';
 
 const agent = await BrowserUse.create({
   model: 'openrouter/openai/gpt-5.6-luna',
+  browser: Browser.cloud({ apiKey: process.env.BROWSER_USE_API_KEY! }),
   workspace: './work',
 });
 


### PR DESCRIPTION
Make the main README example start a Browser Use Cloud browser using `BROWSER_USE_API_KEY`. Readers can run the first example without installing Chrome locally; `agent.close()` retains ownership and stops the created cloud browser.

Validation: extracted the exact TypeScript example and typechecked it against the SDK; README formatting and `git diff --check` pass. Documentation only, with no runtime, API, persisted-data or eval configuration changes. Revert this commit to restore the local-browser example.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the README quickstart to use a Browser Use Cloud browser, so readers can run the example without installing Chrome locally. The example now requires setting `BROWSER_USE_API_KEY` and uses `Browser.cloud()`; `agent.close()` retains ownership and stops the created cloud browser. This is a documentation-only change.

<sup>Written for commit 5194acd2769da52b796ad6d4c4fc0b59118aae4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use-js/pull/2?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

