### PR TITLE
Introduce Browser Use Pi and @browser_use/pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,35 @@
 <img src="https://raw.githubusercontent.com/browser-use/browser-use-js/main/docs/public/banner.webp" alt="A white arch above the clouds" width="100%" />
 
-# Browser Use JS
+# Browser Use Pi
 
-**Pi, with a browser.** A small TypeScript SDK for agents that write JavaScript and control Chrome through raw CDP.
+**Browser Use, built on Pi Mono. In TypeScript.**
 
-The agent gets a persistent JS session, an accessibility tree, screenshots, and a workspace. It writes the rest. No Playwright. No selector engine. No fork of Pi.
+Pi Mono + a persistent V8 REPL + raw CDP. The agent writes JavaScript, controls Chrome, and builds the helpers it needs as it goes.
+
+```text
+Your task → Pi Mono → persistent V8 REPL → raw CDP → Chrome
+                ↑                                    │
+                └──────── AX tree + screenshots ──────┘
+```
+
+The programmability of Browser Harness, with sessions, saved logins, streaming and typed results. One SDK you can put in your app.
 
 ## Start
 
-Runs in **Node 22.19+** or **Bun 1.3.14+**. Bun also needs Node installed for the execution worker. The example uses [Browser Use Cloud](https://github.com/browser-use/browser-use-js/blob/main/docs/sessions.md), so no local Chrome installation is needed. Install with npm, pnpm or Bun:
-
 ```sh
-npm install @browser_use/js
+npm install @browser_use/pi
+# or: pnpm add @browser_use/pi
+# or: bun add @browser_use/pi
 export OPENROUTER_API_KEY=...
 export BROWSER_USE_API_KEY=...
 ```
 
 ```ts
-import { Browser, BrowserUse } from '@browser_use/js';
+import { Browser, BrowserUse } from '@browser_use/pi';
 
 const agent = await BrowserUse.create({
   model: 'openrouter/openai/gpt-5.6-luna',
+  reasoning: 'xhigh',
   browser: Browser.cloud({ apiKey: process.env.BROWSER_USE_API_KEY! }),
   workspace: './work',
 });
@@ -34,23 +43,20 @@ try {
 }
 ```
 
-Save as `agent.ts`. Run with `node agent.ts` or `bun agent.ts`.
+Save as `agent.ts`. Run with `node agent.ts` or `bun agent.ts`. Uses [Browser Use Cloud](docs/sessions.md); no local Chrome installation needed.
 
-## How it works
+**Node 22.19+ · Bun 1.3.14+**. Bun also needs Node for the V8 worker.
 
-```text
-Your task → upstream Pi → persistent JavaScript → raw CDP → Chrome
-                  ↑          AX tree / screenshots          │
-                  └─────────────────────────────────────────┘
-```
+## Keep building
 
-AX first. Screenshots when useful. Real mouse and keyboard input. Small primitives, agent-written helpers.
+- **Models:** upstream Pi's model catalog and transports, with custom providers supported. Model capabilities and provider access vary. [Models](docs/models.md)
+- **Sessions:** follow-ups, saved logins, persistent workspaces, cloud browsers or your own Chrome. [Sessions](docs/sessions.md)
+- **Control:** streaming, hooks, typed results and compaction. Cap steps, time or cost and keep partial work. [API](docs/api.md)
+- **Show the work:** interaction highlights, recordings and GIF exports. [Examples](examples/README.md)
 
-Follow-ups, saved logins, typed results, streaming, hooks, compaction, and GIF/video exports are included. JavaScript runs in a killable worker so a bad cell cannot hang your application. It has filesystem and network access; use an isolated machine for untrusted tasks.
+[Quickstart](docs/quickstart.md) · [Browser primitives](docs/browser.md) · [Python](docs/python.md) · [Historical benchmarks](docs/benchmarks.md)
 
-[Quickstart](https://github.com/browser-use/browser-use-js/blob/main/docs/quickstart.md) · [API](https://github.com/browser-use/browser-use-js/blob/main/docs/api.md) · [Browser primitives](https://github.com/browser-use/browser-use-js/blob/main/docs/browser.md) · [Sessions](https://github.com/browser-use/browser-use-js/blob/main/docs/sessions.md) · [Models](https://github.com/browser-use/browser-use-js/blob/main/docs/models.md) · [Python](https://github.com/browser-use/browser-use-js/blob/main/docs/python.md) · [Historical benchmarks](https://github.com/browser-use/browser-use-js/blob/main/docs/benchmarks.md)
-
-[Eight TypeScript examples](examples/README.md): extraction, QA + GIF, EHR, forms, Link, 1Password, job applications and research.
+JavaScript runs in a killable worker with filesystem and network access. Use an isolated machine for untrusted tasks. Anonymous run counters are enabled; disable with `telemetry: false` or `DO_NOT_TRACK=1`. [Telemetry](docs/api.md#telemetry)
 
 ## Develop
 
@@ -60,7 +66,3 @@ npm run check
 npm run docs:build
 npm run test:python
 ```
-
-Anonymous run counters are enabled. Disable with `telemetry: false` or `DO_NOT_TRACK=1`. [Payload](https://github.com/browser-use/browser-use-js/blob/main/docs/api.md#telemetry).
-
-The [eval adapter](https://github.com/browser-use/browser-use-js/blob/main/eval/README.md) keeps benchmark configuration explicit. Historical scores do not establish this simplified version’s performance.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://raw.githubusercontent.com/browser-use/browser-use-js/main/docs/public/banner.webp" alt="A white arch above the clouds" width="100%" />
+<img src="https://raw.githubusercontent.com/browser-use/browser-use-pi/main/docs/public/banner.webp" alt="A white arch above the clouds" width="100%" />
 
 # Browser Use Pi
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -6,7 +6,7 @@ export default defineConfig({
   cleanUrls: true,
   themeConfig: {
     logo: '/mark.svg',
-    nav: [{ text: 'GitHub', link: 'https://github.com/browser-use/browser-use-js/tree/main' }],
+    nav: [{ text: 'GitHub', link: 'https://github.com/browser-use/browser-use-pi/tree/main' }],
     sidebar: [
       { text: 'Quickstart', link: '/quickstart' },
       { text: 'Models', link: '/models' },

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,8 +1,8 @@
 import { defineConfig } from 'vitepress';
 
 export default defineConfig({
-  title: 'Browser Use JS',
-  description: 'Pi, with a browser. Persistent JavaScript and raw CDP.',
+  title: 'Browser Use Pi',
+  description: 'Browser Use, built on Pi. Persistent V8 REPL + raw CDP, in TypeScript.',
   cleanUrls: true,
   themeConfig: {
     logo: '/mark.svg',

--- a/docs/api.md
+++ b/docs/api.md
@@ -46,7 +46,7 @@ The default output is a string. Schema validation checks shape; `validateResult(
 | `compaction`, `maxContextChars`                     | Enabled, 240,000 characters         |
 | `signal`, `onEvent`, `observe`, `observerTimeoutMs` | Cancellation and observations       |
 
-[Type definitions](https://github.com/browser-use/browser-use-js/blob/main/src/types.ts) are the complete contract. Browser launch options live in [browser.ts](https://github.com/browser-use/browser-use-js/blob/main/src/browser.ts).
+[Type definitions](https://github.com/browser-use/browser-use-pi/blob/main/src/types.ts) are the complete contract. Browser launch options live in [browser.ts](https://github.com/browser-use/browser-use-pi/blob/main/src/browser.ts).
 
 ## Events and hooks
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -5,7 +5,7 @@
 ## Typed results
 
 ```js
-import { BrowserUse, Type } from '@browser_use/js';
+import { BrowserUse, Type } from '@browser_use/pi';
 const agent = await BrowserUse.create({ model: 'openrouter/openai/gpt-5.6-luna' });
 try {
   const result = await agent.run('Read the page title at example.com.', {

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -18,8 +18,8 @@ For `b430a91`, Hard evaluation ID is `ed2fb652-9858-4a36-bac2-60b0d3270302`; V2 
 
 The old reports are preserved at immutable commit `416b9906f0dbb5784ea4aa162345453842c260c3`:
 
-- [Run evidence](https://github.com/browser-use/browser-use-js/tree/416b9906f0dbb5784ea4aa162345453842c260c3/evidence)
-- [Benchmark analysis](https://github.com/browser-use/browser-use-js/blob/416b9906f0dbb5784ea4aa162345453842c260c3/docs/benchmark-overview.md)
-- [Trace audits](https://github.com/browser-use/browser-use-js/tree/416b9906f0dbb5784ea4aa162345453842c260c3/docs)
+- [Run evidence](https://github.com/browser-use/browser-use-pi/tree/416b9906f0dbb5784ea4aa162345453842c260c3/evidence)
+- [Benchmark analysis](https://github.com/browser-use/browser-use-pi/blob/416b9906f0dbb5784ea4aa162345453842c260c3/docs/benchmark-overview.md)
+- [Trace audits](https://github.com/browser-use/browser-use-pi/tree/416b9906f0dbb5784ea4aa162345453842c260c3/docs)
 
-The current repository keeps the [eval adapter](https://github.com/browser-use/browser-use-js/blob/main/eval/README.md) and automated tests. For a performance claim, freeze SDK SHA, task IDs, model, reasoning, budgets, judge, environment and retries. Run matched arms and inspect failures. A tiny model smoke proves integration, not benchmark parity.
+The current repository keeps the [eval adapter](https://github.com/browser-use/browser-use-pi/blob/main/eval/README.md) and automated tests. For a performance claim, freeze SDK SHA, task IDs, model, reasoning, budgets, judge, environment and retries. Run matched arms and inspect failures. A tiny model smoke proves integration, not benchmark parity.

--- a/docs/browser.md
+++ b/docs/browser.md
@@ -31,7 +31,7 @@ await page.clickAt((q[0] + q[2] + q[4] + q[6]) / 4, (q[1] + q[3] + q[5] + q[7]) 
 // Inspect the actual outcome. Coordinates can hit an overlay.
 ```
 
-Prefer AX for discovery and state. Use page evaluation for extraction, screenshots for visual questions, and raw CDP for typing, uploads and frame routing. The [agent prompt](https://github.com/browser-use/browser-use-js/blob/main/src/prompt.ts) teaches these recipes. Reusable helpers belong in the agent’s workspace.
+Prefer AX for discovery and state. Use page evaluation for extraction, screenshots for visual questions, and raw CDP for typing, uploads and frame routing. The [agent prompt](https://github.com/browser-use/browser-use-pi/blob/main/src/prompt.ts) teaches these recipes. Reusable helpers belong in the agent’s workspace.
 
 `artifact(name, data)` creates a new file; `checkpoint(name, value)` atomically saves JSON. `reconnect()` resets CDP; reacquire handles and inspect before acting. `finish_from_js({expression})` delivers an existing variable without asking the model to rewrite it.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,9 +1,9 @@
 ---
 layout: home
 hero:
-  name: Browser Use JS
-  text: Pi, with a browser.
-  tagline: Persistent JavaScript. Raw CDP. Let the agent write the rest.
+  name: Browser Use Pi
+  text: Browser Use, built on Pi.
+  tagline: Pi Mono + persistent V8 REPL + raw CDP. In TypeScript.
   image:
     src: /mark.svg
     alt: Browser Use

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,5 +13,5 @@ hero:
       link: /quickstart
     - theme: alt
       text: GitHub
-      link: https://github.com/browser-use/browser-use-js/tree/main
+      link: https://github.com/browser-use/browser-use-pi/tree/main
 ---

--- a/docs/models.md
+++ b/docs/models.md
@@ -1,6 +1,6 @@
 # Models
 
-Use `provider/model`. Browser Use JS uses upstream Pi’s pinned model catalog and transports; it does not fork the model loop or silently substitute models.
+Use `provider/model`. Browser Use Pi uses upstream Pi’s pinned model catalog and transports; it does not fork the model loop or silently substitute models.
 
 | Example                              | Environment variable |
 | ------------------------------------ | -------------------- |

--- a/docs/python.md
+++ b/docs/python.md
@@ -32,7 +32,7 @@ Session methods include `events`, `pause`, `resume`, `steer`, `cancel`, `execute
 
 Custom tools validate input/output with Pydantic. Async callbacks are cancelled with the run. Synchronous callbacks run in a thread and must cooperate with cancellation. Recursive/external schema references fail explicitly.
 
-Use `node='/path/to/node'` to choose the runtime. This is a separate client, not a drop-in replacement for `browser_use.beta.Agent`. The [client source](https://github.com/browser-use/browser-use-js/tree/main/python/browser_use_next) is the complete bridge contract.
+Use `node='/path/to/node'` to choose the runtime. This is a separate client, not a drop-in replacement for `browser_use.beta.Agent`. The [client source](https://github.com/browser-use/browser-use-pi/tree/main/python/browser_use_next) is the complete bridge contract.
 
 For limited runs, `result.partial` exposes the latest published checkpoint as a dictionary with `path` and `value`. It is unvalidated partial data; `result.output` remains reserved for completed results. Enable interaction highlights with `highlightActions=True` on creation.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,18 +1,19 @@
-# Pi, with a browser
+# Browser Use, built on Pi
 
-A TypeScript SDK. The agent writes JavaScript, sees Chrome’s accessibility tree, and uses raw CDP. Pi supplies the model loop. Browser Use JS adds the browser and a persistent session.
+A TypeScript SDK. The agent writes JavaScript, sees Chrome’s accessibility tree, and uses raw CDP. Pi supplies the model loop. Browser Use Pi adds the browser and a persistent session.
 
 ## Install
 
 Run your app with **Node 22.19+** or **Bun 1.3.14+**. Bun also requires Node on `PATH`: the persistent JavaScript worker uses Node’s V8 inspector. Set `BROWSER_USE_NODE=/absolute/path/to/node` to choose that executable. The worker does not inherit host preload flags or API keys.
 
-Use local Chrome or [Browser Use Cloud](./sessions.md). Runtime checks cover macOS; Windows has not been verified.
+Use local Chrome or [Browser Use Cloud](./sessions.md). Runtime checks cover macOS; Windows has not been verified. The SDK requires a Node process and filesystem, so it does not run directly inside Cloudflare Workers. A remote browser does not remove that runtime requirement.
 
 ```sh
-npm install @browser_use/js
-# or: pnpm add @browser_use/js
-# or: bun add @browser_use/js
+npm install @browser_use/pi
+# or: pnpm add @browser_use/pi
+# or: bun add @browser_use/pi
 export OPENROUTER_API_KEY=...
+export BROWSER_USE_API_KEY=...
 ```
 
 ## Run
@@ -20,10 +21,12 @@ export OPENROUTER_API_KEY=...
 Save as `agent.ts`:
 
 ```ts
-import { BrowserUse } from '@browser_use/js';
+import { Browser, BrowserUse } from '@browser_use/pi';
 
 const agent = await BrowserUse.create({
   model: 'openrouter/openai/gpt-5.6-luna',
+  reasoning: 'xhigh',
+  browser: Browser.cloud({ apiKey: process.env.BROWSER_USE_API_KEY! }),
   workspace: './work',
   log: 'pretty',
 });
@@ -46,18 +49,22 @@ bun agent.ts
 
 Use [models](./models.md) for credentials, [sessions](./sessions.md) for login and persistence, and [API](./api.md) for output, events and hooks.
 
+## Moving from `@browser_use/js`
+
+Install `@browser_use/pi` and change your imports. The `BrowserUse` API, browser options, environment variables, profile directories and session history format are unchanged. The earlier package remains available; this rename does not migrate or delete existing data.
+
 ## Publish to npm (maintainers)
 
-The public package is `@browser_use/js`. Use an npm account with publish permission in the `browser_use` organization and complete npm's required 2FA setup.
+The public package is `@browser_use/pi`. Use an npm account with publish permission in the `browser_use` organization and complete npm's required 2FA setup.
 
 ```sh
 npm login
 npm whoami
 npm run check && npm test && npm run test:bun
 npm pack
-npm publish ./browser_use-js-0.1.0.tgz --access public --dry-run
+npm publish ./browser_use-pi-0.1.0.tgz --access public --dry-run
 # After verifying that exact tarball:
-npm publish ./browser_use-js-0.1.0.tgz --access public
+npm publish ./browser_use-pi-0.1.0.tgz --access public
 ```
 
 `npm test` runs the full Node suite. `npm run test:bun` runs browser, agent, session, policy, recording and recovery tests in Bun; Node-specific test mocks stay in the Node suite. Install and smoke-test the tarball in a clean project before publishing. npm versions cannot be overwritten; bump the version for each later release. For automated releases, configure [npm trusted publishing](https://docs.npmjs.com/trusted-publishers) for the final GitHub repository name. No npm token needs to live in this repository.

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -1,7 +1,7 @@
 # Sessions, login and files
 
 ```js
-import { Browser, BrowserUse } from '@browser_use/js';
+import { Browser, BrowserUse } from '@browser_use/pi';
 
 const agent = await BrowserUse.create({
   model: 'openrouter/openai/gpt-5.6-luna',
@@ -31,7 +31,7 @@ Reuse a profile to keep login. Reuse a workspace to keep files. Restore history 
 ## Choose a browser
 
 ```js
-import { Browser, BrowserUse } from '@browser_use/js';
+import { Browser, BrowserUse } from '@browser_use/pi';
 
 // Browser Use Cloud. close() stops the browser this session creates.
 const browser = Browser.cloud({
@@ -56,7 +56,7 @@ try {
 }
 ```
 
-Real Chrome must expose CDP. Enable `chrome://inspect/#remote-debugging`; Browser Use JS discovers `DevToolsActivePort` on macOS, Linux and Windows. It never copies your profile, relaunches your browser, or grants OS permissions. Pass `Browser.chrome({ cdpUrl })` for an explicit endpoint. `profileDir` in this mode selects the existing user-data root for discovery. The legacy `{cdpUrl}` and local browser options still work.
+Real Chrome must expose CDP. Enable `chrome://inspect/#remote-debugging`; Browser Use Pi discovers `DevToolsActivePort` on macOS, Linux and Windows. It never copies your profile, relaunches your browser, or grants OS permissions. Pass `Browser.chrome({ cdpUrl })` for an explicit endpoint. `profileDir` in this mode selects the existing user-data root for discovery. The legacy `{cdpUrl}` and local browser options still work.
 
 A local `profileDir` stores cookies, local storage and IndexedDB on disk. First run: use `headless: false`, sign in, then close normally. Next run: reuse that directory. Without it, the local profile is temporary and deleted at close. Profile locks reject concurrent SDK owners; after a crash, verify Chrome and the SDK have exited before removing `.bu-pi.lock`. A Chrome profile is sensitive data, not a portable login export.
 
@@ -94,7 +94,7 @@ Each session accepts one operation at a time. Use separate sessions for concurre
 Enable `recording: true` on creation. When a run returns `recordingPath`:
 
 ```js
-import { exportRecording } from '@browser_use/js';
+import { exportRecording } from '@browser_use/pi';
 await exportRecording(result.recordingPath, { output: './demo.gif' });
 ```
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -33,7 +33,7 @@ Set `BROWSER=cloud` for Browser Use Cloud, or `BROWSER=local` for isolated local
 **Link:** install `@stripe/link-cli@0.18.0` and put its `link-cli` executable on PATH. Check `link-cli auth status --format json`. For a new session:
 
 ```sh
-link-cli auth login --client-name "Browser Use JS" --scope "userinfo:read payment_methods.agentic"
+link-cli auth login --client-name "Browser Use Pi" --scope "userinfo:read payment_methods.agentic"
 ```
 
 For an existing session missing payment access, use `auth upgrade` with the same scope. The example inspects a test checkout, creates a `--test` card request, prints its approval URL, waits up to eight minutes, then prefills and cancels the unused request. It never clicks Pay. It supports ordinary card forms, not Link Pay Tokens or HTTP 402 flows. Keep the checkout directly revisitable: preflight and filling use separate browsers.

--- a/examples/apply-to-job.ts
+++ b/examples/apply-to-job.ts
@@ -1,4 +1,4 @@
-import { Browser, BrowserUse, Type } from '@browser_use/js';
+import { Browser, BrowserUse, Type } from '@browser_use/pi';
 import { copyFile, mkdir, readFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 

--- a/examples/ehr.ts
+++ b/examples/ehr.ts
@@ -1,4 +1,4 @@
-import { Browser, BrowserUse, Type } from '@browser_use/js';
+import { Browser, BrowserUse, Type } from '@browser_use/pi';
 
 const url = process.env.EHR_URL;
 if (!url) throw new Error('Set EHR_URL to an EHR sandbox containing synthetic patient TEST-1001.');

--- a/examples/extract.ts
+++ b/examples/extract.ts
@@ -1,4 +1,4 @@
-import { Browser, BrowserUse, Type } from '@browser_use/js';
+import { Browser, BrowserUse, Type } from '@browser_use/pi';
 
 // A website becomes a typed dataset and a CSV, with source URLs for every row.
 const agent = await BrowserUse.create({

--- a/examples/form.ts
+++ b/examples/form.ts
@@ -1,4 +1,4 @@
-import { Browser, BrowserUse, Type } from '@browser_use/js';
+import { Browser, BrowserUse, Type } from '@browser_use/pi';
 
 const agent = await BrowserUse.create({
   model: process.env.MODEL || 'openrouter/openai/gpt-5.6-luna',
@@ -15,7 +15,7 @@ try {
     `Open ${process.env.START_URL || 'https://httpbin.org/forms/post'}.
     Fill the test pizza form: customer Avery Example, phone 202-555-0142,
     email avery@example.com, medium pizza, cheese and mushroom toppings,
-    delivery time 18:30, comment "Synthetic Browser Use JS demo".
+    delivery time 18:30, comment "Synthetic Browser Use Pi demo".
     Submit this demo form once. Inspect the response and verify the submitted fields.
     If the submission result is ambiguous, report that instead of submitting again.`,
     {

--- a/examples/onepassword.ts
+++ b/examples/onepassword.ts
@@ -1,4 +1,4 @@
-import { Browser, BrowserUse, Type } from '@browser_use/js';
+import { Browser, BrowserUse, Type } from '@browser_use/pi';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 

--- a/examples/qa.ts
+++ b/examples/qa.ts
@@ -1,4 +1,4 @@
-import { Browser, BrowserUse, Type, exportRecording } from '@browser_use/js';
+import { Browser, BrowserUse, Type, exportRecording } from '@browser_use/pi';
 import { join } from 'node:path';
 
 const url = process.env.START_URL;

--- a/examples/research.ts
+++ b/examples/research.ts
@@ -1,4 +1,4 @@
-import { Browser, BrowserUse } from '@browser_use/js';
+import { Browser, BrowserUse } from '@browser_use/pi';
 
 const task = process.argv.slice(2).join(' ');
 if (!task) throw new Error('Usage: node examples/research.ts "Your browser task"');

--- a/examples/stripe-link.ts
+++ b/examples/stripe-link.ts
@@ -1,4 +1,4 @@
-import { Browser, BrowserUse, Type } from '@browser_use/js';
+import { Browser, BrowserUse, Type } from '@browser_use/pi';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { setTimeout } from 'node:timers/promises';
@@ -98,7 +98,7 @@ let request = await link([
   '--currency',
   checkout.currency,
   '--context',
-  `Browser Use JS test checkout demonstration for ${purchase}. Inspect and prefill a test card form for the verified total only. Do not submit payment or place an order.`,
+  `Browser Use Pi test checkout demonstration for ${purchase}. Inspect and prefill a test card form for the verified total only. Do not submit payment or place an order.`,
 ]);
 if (typeof request.id !== 'string') throw new Error('Link returned no spend request ID.');
 const id = request.id;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@browser_use/js",
+  "name": "@browser_use/pi",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@browser_use/js",
+      "name": "@browser_use/pi",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/browser-use/browser-use-js.git"
+    "url": "git+https://github.com/browser-use/browser-use-pi.git"
   },
   "bin": {
     "bu-pi-server": "./dist/server.js"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@browser_use/js",
+  "name": "@browser_use/pi",
   "version": "0.1.0",
-  "description": "A small, programmable web agent. Pi models, persistent JavaScript, real browsers.",
+  "description": "Browser Use, built on Pi. Persistent V8 REPL + raw CDP, in TypeScript.",
   "type": "module",
   "license": "MIT",
   "engines": {

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -306,7 +306,7 @@ export function approveChromeConnection(signal: AbortSignal): Promise<string> {
       if (error)
         reject(
           new Error(
-            'Chrome approval needs macOS Accessibility permission for the app running Browser Use JS. Accept Chrome’s prompt manually, or grant that permission.',
+            'Chrome approval needs macOS Accessibility permission for the app running Browser Use Pi. Accept Chrome’s prompt manually, or grant that permission.',
           ),
         );
       else resolve(stdout.trim());

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -27,7 +27,7 @@ export async function workerExecutable(): Promise<string> {
     // Do not expose subprocess output or inherit provider keys and preload flags.
   }
   throw new Error(
-    'Browser Use JS needs Node.js 22.19+ for its JavaScript worker, including when your app runs in Bun. Install Node on PATH or set BROWSER_USE_NODE to its absolute executable path.',
+    'Browser Use Pi needs Node.js 22.19+ for its JavaScript worker, including when your app runs in Bun. Install Node on PATH or set BROWSER_USE_NODE to its absolute executable path.',
   );
 }
 

--- a/test/examples.test.mjs
+++ b/test/examples.test.mjs
@@ -24,9 +24,9 @@ const cases = [
   'research',
 ];
 const html = (body) =>
-  `<!doctype html><html><head><title>Browser Use JS test fixture</title></head><body>${body}</body></html>`;
+  `<!doctype html><html><head><title>Browser Use Pi test fixture</title></head><body>${body}</body></html>`;
 const fixture = html(`
-<h1>Browser Use JS sandbox</h1><p>Test checkout: Example Store, Demo book, final total USD 10.00. Tax and shipping included.</p>
+<h1>Browser Use Pi sandbox</h1><p>Test checkout: Example Store, Demo book, final total USD 10.00. Tax and shipping included.</p>
 <p>Patient TEST-1001: Avery Example, DOB 1990-01-02</p>
 ${Array.from({ length: 10 }, (_, i) => `<article><a href="?book=${i}">Book ${i + 1}</a><p>USD ${i + 1}.00, In stock</p></article>`).join('')}
 <form id="pizza"><label>Customer <input name="customer"></label><label>Phone <input name="phone"></label><label>Email <input name="email" type="email"></label><label>Pizza size <select name="size"><option>small</option><option>medium</option><option>large</option></select></label><label><input type="checkbox" name="cheese">Cheese</label><label><input type="checkbox" name="mushroom">Mushroom</label><label>Delivery time <input name="time" type="time"></label><label>Comment <textarea name="comment"></textarea></label><button>Submit demo form</button></form>


### PR DESCRIPTION
Introduce **Browser Use Pi** and publish the npm package as **@browser_use/pi**. The README now leads with “Browser Use, built on Pi Mono. In TypeScript.” and a Pi → persistent V8 REPL → raw CDP → Chrome diagram, followed by a cloud-browser example.

Updates package identity, lockfile identity, documentation and all eight TypeScript example imports. The public BrowserUse API, environment variables, CLI name, Python client, profile directories and history format stay compatible. Existing @browser_use/js installations remain available; migration is a dependency/import change. Source changes are limited to two human-facing error labels. Agent prompt, execution behavior, model routing and dependency versions are unchanged.

Validation: build, TypeScript check, README formatting and docs build pass. All 150 Node tests pass. The exact tarball installs with npm, pnpm and Bun; all six combinations of installer × Node/Bun host pass real-local-Chrome smokes for persistent execution, screenshots, typed output, follow-ups, partial results, secret redaction, domain policy and timeout recovery. Those smokes use Pi’s faux model provider, not paid model calls. npm publish dry-run passes. No claim of direct Cloudflare Workers support or benchmark leadership is included.

Rollout: publish the verified @browser_use/pi tarball with the matching README. Benchmark comparisons continue separately and do not gate this release; no deprecation or deletion of @browser_use/js. The new package name is an npm identity change, not an automatic upgrade for existing users. Reverting the PR restores the previous branding and package identity; any published npm version cannot be overwritten.
