### PR TITLE
Fix extraction example CSV path output

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -55,4 +55,6 @@ The job example reads facts from your JSON file and attaches a real PDF by trans
 }
 ```
 
+The extraction result contains `books` and `csvPath`, an absolute path to the saved CSV. It checks that the file exists and is non-empty before printing a completed result.
+
 Each script caps steps, time and cost. A stopped run can return partial progress; inspect its status before treating the task as complete.

--- a/examples/extract.ts
+++ b/examples/extract.ts
@@ -1,3 +1,5 @@
+import { stat } from 'node:fs/promises';
+import { resolve } from 'node:path';
 import { Browser, BrowserUse, Type } from '@browser_use/pi';
 
 // A website becomes a typed dataset and a CSV, with source URLs for every row.
@@ -13,12 +15,13 @@ const agent = await BrowserUse.create({
   highlightActions: true,
 });
 try {
+  const csvPath = resolve(agent.workspace, 'books.csv');
   const result = await agent.run(
     `Visit ${process.env.START_URL || 'https://books.toscrape.com/'}.
     Collect the first 10 books in displayed order. Open their detail pages to verify title,
     price, currency and stock status. Keep missing values null; do not guess.
     Save books.csv in the workspace and publish a checkpoint after each verified book.
-    Return the records and the CSV path.`,
+    Return the records and csvPath: the absolute path to that file, not CSV contents.`,
     {
       schema: Type.Object({
         books: Type.Array(
@@ -30,13 +33,20 @@ try {
             url: Type.String(),
           }),
         ),
-        csv: Type.String(),
+        csvPath: Type.Literal(csvPath, {
+          description: 'Absolute path to the saved books.csv file.',
+        }),
       }),
       maxSteps: 40,
       timeoutMs: 300_000,
       maxCostUsd: 2,
     },
   );
+  if (result.status === 'completed') {
+    const file = await stat(csvPath);
+    if (!file.isFile() || file.size === 0)
+      throw new Error(`CSV file is empty or not a file: ${csvPath}`);
+  }
   console.log(
     JSON.stringify(
       result.status === 'completed' ? result.output : (result.partial?.value ?? result.text),

--- a/test/examples.test.mjs
+++ b/test/examples.test.mjs
@@ -73,10 +73,20 @@ function resumePDF() {
   return Buffer.from(text);
 }
 
-for (const name of [...cases, 'link-denied', 'op-failed'])
+for (const name of [
+  ...cases,
+  'extract-invalid-paths',
+  'extract-missing',
+  'extract-empty',
+  'link-denied',
+  'op-failed',
+])
   test(
     `TypeScript example: ${name} (${browser})`,
-    { timeout: process.env.EXAMPLE_LIVE_MODEL ? 480_000 : 120_000 },
+    {
+      timeout: process.env.EXAMPLE_LIVE_MODEL ? 480_000 : 120_000,
+      skip: Boolean(process.env.EXAMPLE_LIVE_MODEL) && name.startsWith('extract-'),
+    },
     async () => {
       const dir = await mkdtemp(join(tmpdir(), 'bu-example-'));
       const events = [];
@@ -101,8 +111,13 @@ for (const name of [...cases, 'link-denied', 'op-failed'])
         server.listen(Number(process.env.EXAMPLE_FIXTURE_PORT || 0), '127.0.0.1', r),
       );
       const url = process.env.EXAMPLE_FIXTURE_ORIGIN || `http://127.0.0.1:${server.address().port}`;
-      const example =
-        name === 'link-denied' ? 'stripe-link' : name === 'op-failed' ? 'onepassword' : name;
+      const example = name.startsWith('extract-')
+        ? 'extract'
+        : name === 'link-denied'
+          ? 'stripe-link'
+          : name === 'op-failed'
+            ? 'onepassword'
+            : name;
       await mkdir(join(dir, 'bin'));
       await mkdir(join(dir, 'work'));
       await writeFile(join(dir, 'resume.pdf'), resumePDF());
@@ -138,7 +153,7 @@ process.stdout.write(JSON.stringify(value));`,
             inStock: true,
             url: `${url}/?book=${i}`,
           })),
-          csv: 'books.csv',
+          csvPath: join(dir, 'work/books.csv'),
         },
         qa: {
           tested: ['Search'],
@@ -181,6 +196,8 @@ process.stdout.write(JSON.stringify(value));`,
         'apply-to-job': `var bytes=(await fs.readFile('resume.pdf')).toString('base64');await page.evaluate(b64=>{document.querySelector('#applicant').value='Avery Example';const dt=new DataTransfer();dt.items.add(new File([Uint8Array.from(atob(b64),c=>c.charCodeAt(0))],'resume.pdf',{type:'application/pdf'}));const input=document.querySelector('#resume');input.files=dt.files;input.dispatchEvent(new Event('change',{bubbles:true}));},bytes);await fs.writeFile('application-review.md','Attached resume.pdf. Not submitted.');`,
         research: `console.log(await page.evaluate(()=>document.title));`,
       };
+      if (name === 'extract-missing') actions.extract = '';
+      if (name === 'extract-empty') actions.extract = `await fs.writeFile('books.csv', '');`;
       const preload = join(dir, 'preload.mjs');
       await writeFile(
         preload,
@@ -198,7 +215,12 @@ BrowserUse.create=async options=>{
   if(options.sensitiveData){action="var nodes=(await snapshot()).nodes;await fillSecret('cardNumber',nodes.find(n=>n.role==='textbox'&&n.name==='Card number').id);await fillSecret('expiry',nodes.find(n=>n.role==='textbox'&&n.name==='Expiry').id);await fillSecret('cvc',nodes.find(n=>n.role==='textbox'&&n.name==='CVC').id);await page.evaluate(()=>document.querySelector('#payment').dispatchEvent(new Event('change')));";output={filled:true,submitted:false,needsHuman:[]};}
   else output={supported:true,merchant:'Example Store',amountCents:1000,currency:'usd',reason:'Test checkout'};
  }
- faux.setResponses([call('javascript',{code:'var fs=await import("node:fs/promises");await page.goto('+${JSON.stringify(JSON.stringify(url))}+');'+action+'await new Promise(r=>setTimeout(r,150));console.log("fixture action complete");'}),context=>{const tool=context.messages.findLast(m=>m.role==='toolResult');assert.equal(tool.isError,false,JSON.stringify(tool.content));return call('finish',{result:output});}]);
+ const invalidPaths = ${JSON.stringify(name)} === 'extract-invalid-paths' ? [
+  () => call('finish', {result: {...output, csvPath: 'title,price\\nBook 1,1'}}),
+  context => { assert.equal(context.messages.findLast(m=>m.role==='toolResult').isError,true); return call('finish',{result:{...output,csvPath:'/wrong/books.csv'}}); },
+  context => { assert.equal(context.messages.findLast(m=>m.role==='toolResult').isError,true); return call('finish',{result:output}); },
+] : [];
+faux.setResponses([call('javascript',{code:'var fs=await import("node:fs/promises");await page.goto('+${JSON.stringify(JSON.stringify(url))}+');'+action+'await new Promise(r=>setTimeout(r,150));console.log("fixture action complete");'}),context=>{const tool=context.messages.findLast(m=>m.role==='toolResult');assert.equal(tool.isError,false,JSON.stringify(tool.content));return invalidPaths.length ? invalidPaths[0]() : call('finish',{result:output});}, ...invalidPaths.slice(1)]);
  const agent=await original(process.env.EXAMPLE_LIVE_MODEL ? {...options,telemetry:false} : {...options,model:faux.getModel().provider+'/'+faux.getModel().id,models,telemetry:false});
  const run=agent.run.bind(agent);agent.run=async(...args)=>{const result=await run(...args);await writeFile(${JSON.stringify(join(dir, 'result.json'))},JSON.stringify(result));if (process.env.EXAMPLE_LIVE_MODEL && 'qa'===${JSON.stringify(example)}) { assert.ok(result.status==='completed'||result.partial, result.text); } else assert.equal(result.status,'completed',result.text);return result;};return agent;
 };
@@ -264,7 +286,11 @@ BrowserUse.create=async options=>{
             );
           } catch {}
         }
-        assert.equal(failed, ['link-denied', 'op-failed'].includes(name), stderr);
+        assert.equal(
+          failed,
+          ['link-denied', 'op-failed', 'extract-missing', 'extract-empty'].includes(name),
+          stderr,
+        );
         for (const secret of ['fixture-secret-83', '4242424242424242'])
           assert.ok(!(stdout + stderr).includes(secret));
         assert.ok(!events.some((e) => ['charged', 'signed', 'applied'].includes(e.type)));
@@ -279,11 +305,17 @@ BrowserUse.create=async options=>{
             Buffer.from(events.find((e) => e.type === 'upload')?.data.bytes || []),
             resumePDF(),
           );
-        if (name === 'extract')
+        if (example === 'extract' && !failed) {
+          const result = JSON.parse(await readFile(join(dir, 'result.json'), 'utf8'));
+          assert.equal(result.output.csvPath, join(dir, 'work/books.csv'));
+          assert.deepEqual(JSON.parse(stdout), result.output);
           assert.equal(
-            (await readFile(join(dir, 'work/books.csv'), 'utf8')).trim().split('\n').length,
+            (await readFile(result.output.csvPath, 'utf8')).trim().split('\n').length,
             11,
           );
+        }
+        if (name === 'extract-missing') assert.match(stderr, /ENOENT/);
+        if (name === 'extract-empty') assert.match(stderr, /CSV file is empty/);
         if (name === 'qa') {
           const result = JSON.parse(await readFile(join(dir, 'result.json'), 'utf8'));
           const gif = await readFile(join(dir, 'work', `qa-${result.runId}.gif`));


### PR DESCRIPTION
The extraction example accepted CSV text where callers expected a filename. It now returns `csvPath`, constrained to the absolute workspace CSV path, and checks that the file exists and is non-empty before printing a completed result.

Validation: TypeScript build/check and all 13 local-browser example tests passed using a scripted Pi model. Regression cases cover CSV contents and wrong paths followed by correction, missing files, and empty files. No live-provider or cloud-browser run was performed for this fix.

Only the extraction example's output key changes (`csv` → `csvPath`); SDK APIs and the runtime system prompt are unchanged. Consumers parsing this example's stdout must use the new key. No persisted-data migration or package publication. Rollback is a revert of this commit.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the extraction example so it returns the saved CSV's absolute path instead of CSV contents.

Consumers parsing this example's stdout must switch from the `csv` output key to `csvPath`. The example now verifies the CSV file exists and is non-empty before printing a completed result; regression tests cover wrong paths, missing files, and empty files. All 13 local-browser example tests pass; no live-provider run was performed.

<sup>Written for commit ee0b6583145bb526b07b5a195207f1b5c650471d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use-pi/pull/4?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

